### PR TITLE
add riscv64 support

### DIFF
--- a/Xmonk/Makefile
+++ b/Xmonk/Makefile
@@ -9,7 +9,9 @@
 	endif
 
 	# check CPU and supported optimization flags
-	ifneq ($(shell cat /proc/cpuinfo | grep sse3 ) , )
+	ifneq ($(findstring riscv64 , $(shell uname -a )) , )
+		SSE_CFLAGS = 
+	else ifneq ($(shell cat /proc/cpuinfo | grep sse3 ) , )
 		SSE_CFLAGS = -msse3 -mfpmath=sse
 	else ifneq ($(shell cat /proc/cpuinfo | grep sse2 ) , )
 		SSE_CFLAGS = -msse2 -mfpmath=sse


### PR DESCRIPTION
When I tried to build Xmonk, I found that it was optimized for intel cup.
```
g++: error: unrecognized command-line option -msse3
g++: error: unrecognized command-line option -mfpmath=sse
```
But there is no corresponding parameter defined on RISC-V, so I decided not to add CFLAGS if the architecture is RISC-V in the Mikefile.